### PR TITLE
Automate recent news sections

### DIFF
--- a/_data/news.json
+++ b/_data/news.json
@@ -1,0 +1,17 @@
+[
+  {
+    "date": "2025-08-01",
+    "month": "August 2025",
+    "items": [
+      "Three papers accepted at the [59th Hawaii International Conference on System Sciences (HICSS)](https://hicss.hawaii.edu/)",
+      "Passed prospectus defense and entered into Ph.D. candidacy"
+    ]
+  },
+  {
+    "date": "2025-07-01",
+    "month": "July 2025",
+    "items": [
+      "Passed Ph.D. specialty exam"
+    ]
+  }
+]

--- a/index.qmd
+++ b/index.qmd
@@ -28,18 +28,32 @@ I am a computer engineer at the Air Force Research Laboratory and a operations r
 
 ## Recent News
 
-::: {.timeline}
+```{python}
+#| results: asis
+import json
+from pathlib import Path
 
-**August 2025**  
+data_path = Path("_data/news.json")
 
-- Three papers accepted at the [59th Hawaii International Conference on System Sciences (HICSS)](https://hicss.hawaii.edu/)
-- Passed prospectus defense and entered into Ph.D. candidacy
+if data_path.exists():
+    with data_path.open("r", encoding="utf-8") as f:
+        news_entries = json.load(f)
 
-**July 2025**  
+    # Sort by the ISO date field so new entries float to the top regardless of file order.
+    news_entries.sort(key=lambda entry: entry.get("date", ""), reverse=True)
 
-- Passed Ph.D. specialty exam
+    recent_entries = news_entries[:3]
 
-:::
+    print("::: {.timeline}")
+    for entry in recent_entries:
+        print(f"**{entry['month']}**\n")
+        for item in entry.get("items", []):
+            print(f"- {item}")
+        print("")
+    print(":::")
+else:
+    print("::: {.timeline}\n_No news entries available yet._\n:::")
+```
 
 <div style="text-align: center; margin: 20px 0;">
   <a href="news.qmd" class="btn btn-primary" target="_blank" style="border-radius: 24px; padding: 10px 24px;">

--- a/news.qmd
+++ b/news.qmd
@@ -3,4 +3,28 @@ title: "News"
 page-layout: article
 ---
 
-Under construction!
+The news timeline below is generated from the `_data/news.json` file. Add new items there (using the ISO `date` field so entries stay in chronological order) and both this page and the homepage will update automatically.
+
+```{python}
+#| results: asis
+import json
+from pathlib import Path
+
+data_path = Path("_data/news.json")
+
+if data_path.exists():
+    with data_path.open("r", encoding="utf-8") as f:
+        news_entries = json.load(f)
+
+    news_entries.sort(key=lambda entry: entry.get("date", ""), reverse=True)
+
+    print("::: {.timeline}")
+    for entry in news_entries:
+        print(f"**{entry['month']}**\n")
+        for item in entry.get("items", []):
+            print(f"- {item}")
+        print("")
+    print(":::")
+else:
+    print("::: {.timeline}\n_No news entries available yet._\n:::")
+```


### PR DESCRIPTION
## Summary
- store news entries in `_data/news.json` for a single source of truth
- render the full timeline on `news.qmd` from the shared data file
- update `index.qmd` to display the three most recent news months automatically

## Testing
- `quarto render index.qmd` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68dd930accf88331a2a116bad5b05502