### PR TITLE
Auto-populate news timeline from shared data

### DIFF
--- a/assets/data/news.json
+++ b/assets/data/news.json
@@ -1,0 +1,44 @@
+[
+  {
+    "date": "2025-08-01",
+    "title": "August 2025",
+    "items": [
+      {
+        "html": "Three papers accepted at the <a href=\"https://hicss.hawaii.edu/\" target=\"_blank\" rel=\"noopener\">59th Hawaii International Conference on System Sciences (HICSS)</a>"
+      },
+      {
+        "text": "Passed prospectus defense and entered into Ph.D. candidacy"
+      }
+    ]
+  },
+  {
+    "date": "2025-07-01",
+    "title": "July 2025",
+    "items": [
+      {
+        "text": "Passed Ph.D. specialty exam"
+      }
+    ]
+  },
+  {
+    "date": "2025-05-15",
+    "title": "May 2025",
+    "items": [
+      {
+        "text": "Presented invited seminar on biologically-inspired AI/ML for defense applications"
+      },
+      {
+        "html": "Served as panelist for the <a href=\"https://www.informs.org/\" target=\"_blank\" rel=\"noopener\">INFORMS Women in OR/MS</a> webinar series"
+      }
+    ]
+  },
+  {
+    "date": "2025-04-10",
+    "title": "April 2025",
+    "items": [
+      {
+        "text": "Organized AFRL AI/ML community of interest workshop"
+      }
+    ]
+  }
+]

--- a/assets/js/news.js
+++ b/assets/js/news.js
@@ -1,0 +1,122 @@
+(function () {
+  const NEWS_DATA_PATH = "assets/data/news.json";
+
+  async function fetchNewsData(dataPath) {
+    const response = await fetch(dataPath, { cache: "no-cache" });
+    if (!response.ok) {
+      throw new Error(`Failed to fetch news data: ${response.status} ${response.statusText}`);
+    }
+    const data = await response.json();
+    if (!Array.isArray(data)) {
+      throw new Error("News data must be an array.");
+    }
+    return data
+      .map((entry) => ({
+        ...entry,
+        date: entry.date ?? entry.month ?? "",
+      }))
+      .sort((a, b) => {
+        const dateA = Date.parse(a.date) || 0;
+        const dateB = Date.parse(b.date) || 0;
+        return dateB - dateA;
+      });
+  }
+
+  function createListItem(item) {
+    const listItem = document.createElement("li");
+
+    if (item.html) {
+      listItem.innerHTML = item.html;
+      return listItem;
+    }
+
+    if (item.url) {
+      const link = document.createElement("a");
+      link.href = item.url;
+      link.textContent = item.text ?? item.url;
+      link.target = item.newTab === false ? "_self" : "_blank";
+      link.rel = link.target === "_blank" ? "noopener" : "";
+      listItem.appendChild(link);
+      return listItem;
+    }
+
+    listItem.textContent = item.text ?? "";
+    return listItem;
+  }
+
+  function getMonthTitle(entry) {
+    if (entry.title) {
+      return entry.title;
+    }
+    if (entry.month) {
+      return entry.month;
+    }
+    if (entry.date) {
+      const parsed = new Date(entry.date);
+      if (!Number.isNaN(parsed.valueOf())) {
+        return parsed.toLocaleDateString(undefined, { month: "long", year: "numeric" });
+      }
+    }
+    return "";
+  }
+
+  window.renderNews = async function renderNews(options) {
+    const {
+      containerId,
+      limit = null,
+      emptyMessage = "No news available yet. Please check back soon!",
+      dataPath = NEWS_DATA_PATH,
+    } = options ?? {};
+
+    const container = document.getElementById(containerId);
+    if (!container) {
+      console.warn(`renderNews: container with id "${containerId}" not found.`);
+      return;
+    }
+
+    try {
+      const newsEntries = await fetchNewsData(dataPath);
+      const entriesToRender = typeof limit === "number" && limit > 0
+        ? newsEntries.slice(0, limit)
+        : newsEntries;
+
+      container.innerHTML = "";
+
+      if (!entriesToRender.length) {
+        const message = document.createElement("p");
+        message.textContent = emptyMessage;
+        container.appendChild(message);
+        return;
+      }
+
+      const fragment = document.createDocumentFragment();
+
+      entriesToRender.forEach((entry) => {
+        const wrapper = document.createElement("div");
+        wrapper.className = "timeline-month";
+
+        const monthHeading = document.createElement("p");
+        monthHeading.innerHTML = `<strong>${getMonthTitle(entry)}</strong>`;
+        wrapper.appendChild(monthHeading);
+
+        if (Array.isArray(entry.items) && entry.items.length) {
+          const list = document.createElement("ul");
+          entry.items.forEach((item) => {
+            list.appendChild(createListItem(item));
+          });
+          wrapper.appendChild(list);
+        }
+
+        fragment.appendChild(wrapper);
+      });
+
+      container.appendChild(fragment);
+    } catch (error) {
+      console.error(error);
+      container.innerHTML = "";
+      const message = document.createElement("p");
+      message.textContent = emptyMessage;
+      container.appendChild(message);
+    }
+  };
+})();

--- a/index.qmd
+++ b/index.qmd
@@ -29,17 +29,25 @@ I am a computer engineer at the Air Force Research Laboratory and a operations r
 ## Recent News
 
 ::: {.timeline}
-
-**August 2025**  
-
-- Three papers accepted at the [59th Hawaii International Conference on System Sciences (HICSS)](https://hicss.hawaii.edu/)
-- Passed prospectus defense and entered into Ph.D. candidacy
-
-**July 2025**  
-
-- Passed Ph.D. specialty exam
-
+<div id="recent-news"></div>
 :::
+
+<!-- Recent news items are sourced from assets/data/news.json -->
+
+```{=html}
+<script src="assets/js/news.js"></script>
+<script>
+  document.addEventListener("DOMContentLoaded", function () {
+    if (typeof renderNews === "function") {
+      renderNews({
+        containerId: "recent-news",
+        limit: 3,
+        emptyMessage: "Recent news updates coming soon!",
+      });
+    }
+  });
+</script>
+```
 
 <div style="text-align: center; margin: 20px 0;">
   <a href="news.qmd" class="btn btn-primary" target="_blank" style="border-radius: 24px; padding: 10px 24px;">

--- a/news.qmd
+++ b/news.qmd
@@ -3,4 +3,24 @@ title: "News"
 page-layout: article
 ---
 
-Under construction!
+Stay up-to-date with recent milestones, publications, and highlights.
+
+::: {.timeline}
+<div id="news-list"></div>
+:::
+
+<!-- News items are managed in assets/data/news.json -->
+
+```{=html}
+<script src="assets/js/news.js"></script>
+<script>
+  document.addEventListener("DOMContentLoaded", function () {
+    if (typeof renderNews === "function") {
+      renderNews({
+        containerId: "news-list",
+        emptyMessage: "News updates coming soon!",
+      });
+    }
+  });
+</script>
+```

--- a/styles.css
+++ b/styles.css
@@ -37,14 +37,33 @@ body.page-index .grid {
   box-shadow: 0 2px 4px rgba(0,0,0,0.05);
 }
 
-.timeline p {
-  margin-bottom: 1rem;
+.timeline .timeline-month + .timeline-month {
+  margin-top: 1rem;
+}
+
+.timeline .timeline-month p,
+.timeline > p {
+  margin-bottom: 0.5rem;
   padding: 0.5rem 0;
   border-bottom: 1px solid #e9ecef;
 }
 
-.timeline p:last-child {
+.timeline .timeline-month:last-child p,
+.timeline > p:last-child {
   border-bottom: none;
+  margin-bottom: 0;
+}
+
+.timeline ul {
+  margin: 0 0 0.75rem 1.25rem;
+  padding-left: 0.5rem;
+}
+
+.timeline ul li {
+  margin-bottom: 0.35rem;
+}
+
+.timeline ul li:last-child {
   margin-bottom: 0;
 }
 


### PR DESCRIPTION
## Summary
- add a shared JSON data source for news timeline entries
- load recent and full news sections dynamically with a reusable script
- refresh timeline styling to accommodate generated markup

## Testing
- Not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68dd97dcaa3c8331b4c50f704cb85c1b